### PR TITLE
Excitation Output & RTD Measurement Example

### DIFF
--- a/examples/MultiRtdSensor/MultiRtdSensor.ino
+++ b/examples/MultiRtdSensor/MultiRtdSensor.ino
@@ -1,0 +1,159 @@
+/*
+  AD7124 Multiple RTD Sensor Example
+  
+  Reads 2 RTD Sensors as per https://www.analog.com/en/_/media/analog/en/reference-circuits/cn0383/cn0383_16_1024.gif
+
+  Setup in 3-wire mode and requires 2 current excitation sources.
+  Probe 0
+  -AIN0 Excitation source 0
+  -AIN2 Probe +
+  -AIN3 Probe -
+  -AIN1 Excitation source 1
+  -3rd wire tied to RREF
+
+  Probe 1
+  -AIN6 Excitation source 0
+  -AIN4 Probe +
+  -AIN5 Probe -
+  -AIN7 Excitation source 1
+  -3rd wire tied to RREF
+
+  For more on AD7124, see
+  http://www.analog.com/media/en/technical-documentation/data-sheets/AD7124-4.pdf
+
+  This file is part of the NHB_AD7124 library.
+
+  MIT License - A copy of the full text should be included with the library
+
+  Copyright (C) 2025  Aaron Neal
+
+*/
+
+#include <NHB_AD7124.h>
+
+
+const uint8_t csPin = 10;
+
+Ad7124 adc(csPin, 4000000);
+
+
+
+
+// The filter select bits determine the filtering and ouput data rate
+//
+//     1 = Minimum filter, fastest conversion time, maximum output rate.
+//  2047 = Maximum filter, slowest conversion time, minumum output rate.
+//
+// For this example I'll use a setting of 320 with the Sinc3 filter. This 
+// should provide 95dB of 60 Hz rejection and will output at around 20 sps.
+//
+// Of course you can always take your readings at a SLOWER rate than
+// the output data rate. (i.e. logging a reading every  30 seconds)
+//
+// NOTE: Actual output data rates in single conversion mode will be slower
+// than calculated using the formula in the datasheet. This is because of
+// the settling time plus the time it takes to enable or change the channel.
+uint16_t filterSelectBits = 320;
+const long FullScale = 1L << 24;
+
+void setup() {
+
+  //Initialize serial and wait for port to open:
+  Serial.begin (115200);
+  while (!Serial) {;} // wait for serial port to connect. Needed for native USB port only
+
+  Serial.println ("AD7124 2 channel RTD example");
+
+  // Initializes the AD7124 device
+  adc.begin();
+  
+  // Configuring ADC in Full Power Mode (Fastest)
+  adc.setAdcControl(AD7124_OpMode_Continuous, AD7124_FullPower, true); 
+
+  //setup probe 0
+  adc.setup[0].setConfig(AD7124_Ref_ExtRef1, AD7124_Gain_4, true, AD7124_Burnout_Off); 
+  adc.setup[0].setFilter(AD7124_Filter_SINC3, filterSelBits, AD7124_PostFilter_NoPost, true, false);
+  adc.setChannel(0, 0, AD7124_Input_AIN2, AD7124_Input_AIN3, false);
+
+  //setup probe 1
+  adc.setup[1].setConfig(AD7124_Ref_ExtRef1, AD7124_Gain_4, true, AD7124_Burnout_Off); 
+  adc.setup[1].setFilter(AD7124_Filter_SINC3, filterSelBits, AD7124_PostFilter_NoPost, true, false);
+  adc.setChannel(1, 1, AD7124_Input_AIN4, AD7124_Input_AIN5, false);
+}
+
+//we can use burnout to detect disconnected probes
+bool burnoutDetect(uint8_t probe){
+  adc.setup[probe].setConfig(AD7124_Ref_Internal, AD7124_Gain_1, true, AD7124_Burnout_4uA); 
+  delay(5); //wait for burnout current to stabilize
+  double rawAdc = adc.readRaw(probe);
+  adc.setup[probe].setConfig(AD7124_Ref_ExtRef1, AD7124_Gain_4, true, AD7124_Burnout_Off); //return back to normal settings
+  if(rawAdc >= (FullScale-10)){
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void readProbe(uint8_t probe){
+  Serial.printf("Probe %d:", probe);
+
+  //enable setup
+  adc.enableChannel(probe, true);
+  bool openCircuit = burnoutDetect(probe);
+
+  if(openCircuit){
+    Serial.println("Open Circuit Error");
+  } else {
+    //set correct excitation for each probe
+    if(probe == 0){
+      adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN0, AD7124_ExCurrentSource_0, AD7124_ExCurrent_250uA); //probe 1
+      adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN1, AD7124_ExCurrentSource_1, AD7124_ExCurrent_250uA); //probe 1
+    } else {
+      adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN6, AD7124_ExCurrentSource_0, AD7124_ExCurrent_250uA); //probe 1
+      adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN7, AD7124_ExCurrentSource_1, AD7124_ExCurrent_250uA); //probe 1
+    }
+
+    delay(20); //wait for stabilisation
+
+    double rawAdc = adc.readRaw(probe); //read the ADC
+
+    //turn currents off, doesn't matter the channel, there are only 2 sources
+    adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN0, AD7124_ExCurrentSource_0, AD7124_ExCurrent_Off);
+    adc.setExCurrent(AD7124_ExCurrentOutputChannel_AIN1, AD7124_ExCurrentSource_1, AD7124_ExCurrent_Off);
+
+    //disable setup
+    adc.enableChannel(probe, false);
+
+    double resistance = adc.rtd.toResistance(rawAdc1, 4, 5110) * 2; //multiply by 2 because we are using a 2 excitation sources (current is double)
+    double temp = adc.rtd.toTemperature(resistance); //get temperature from resistance,
+    
+    Serial.print(resistance, 2);
+    Serial.print(',');
+    Serial.print(temp, 2);
+    Serial.println();
+  }
+}
+
+void loop() {
+  double reading; 
+
+  uint32_t count = 0;
+  static uint32_t lastCount = 0;
+  uint32_t interval = millis() + 1000;
+
+  while(millis() < interval)
+  { 
+    reading = adc.readFB(0, 2.5, 5.00);
+    
+    
+    Serial.print(reading,4);
+    Serial.print('\t');
+    Serial.print(lastCount);
+    Serial.println("sps");
+
+    count++;
+  }
+
+  lastCount = count; 
+  
+}

--- a/examples/MultiRtdSensor/MultiRtdSensor.ino
+++ b/examples/MultiRtdSensor/MultiRtdSensor.ino
@@ -54,7 +54,9 @@ Ad7124 adc(csPin, 4000000);
 // than calculated using the formula in the datasheet. This is because of
 // the settling time plus the time it takes to enable or change the channel.
 uint16_t filterSelectBits = 320;
-const long FullScale = 1L << 24;
+const long fullScale = 1L << 24;
+const double gain = 4;
+const double rRef = 5110;
 
 void setup() {
 
@@ -87,7 +89,7 @@ bool burnoutDetect(uint8_t probe){
   delay(5); //wait for burnout current to stabilize
   double rawAdc = adc.readRaw(probe);
   adc.setup[probe].setConfig(AD7124_Ref_ExtRef1, AD7124_Gain_4, true, AD7124_Burnout_Off); //return back to normal settings
-  if(rawAdc >= (FullScale-10)){
+  if(rawAdc >= (fullScale-10)){
     return true;
   } else {
     return false;
@@ -124,8 +126,8 @@ void readProbe(uint8_t probe){
     //disable setup
     adc.enableChannel(probe, false);
 
-    double resistance = adc.rtd.toResistance(rawAdc1, 4, 5110) * 2; //multiply by 2 because we are using a 2 excitation sources (current is double)
-    double temp = adc.rtd.toTemperature(resistance); //get temperature from resistance,
+    double resistance = adc.rtd.adcRawToResistance(rawAdc1, gain, rRef) * 2; //multiply by 2 because we are using a 2 excitation sources (current is double)
+    double temp = adc.rtd.resistanceToTemperature(resistance); //get temperature from resistance,
     
     Serial.print(resistance, 2);
     Serial.print(',');

--- a/keywords.txt
+++ b/keywords.txt
@@ -32,6 +32,8 @@ currentChannel	KEYWORD2
 status	KEYWORD2
 toVolts	KEYWORD2
 tempSensorRawToDegC	KEYWORD2
+adcRawToResistance	KEYWORD2
+resistanceToTemperature	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/NHB_AD7124.cpp
+++ b/src/NHB_AD7124.cpp
@@ -380,6 +380,19 @@ double Ad7124::readFB(uint8_t ch, double vEx, double scaleFactor)
   return ((readVolts(ch) * 1000.0) / vEx) * scaleFactor;
 }
 
+//sets the excitation current for a given channel
+int Ad7124::setExCurrent(AD7124_ExCurrentOutputChannel ch, AD7124_ExCurrentSource source, AD7124_ExCurrent current){
+  if (source == AD7124_ExCurrentSource_0) {
+    regs[Reg_IOCon1].value &= ~ (AD7124_IO_CTRL1_REG_IOUT0 (7) | AD7124_IO_CTRL1_REG_IOUT_CH0 (15));
+    regs[Reg_IOCon1].value |= AD7124_IO_CTRL1_REG_IOUT0 (current) | AD7124_IO_CTRL1_REG_IOUT_CH0 (ch);
+  }
+  else {
+    regs[Reg_IOCon1].value &= ~ (AD7124_IO_CTRL1_REG_IOUT1 (7) | AD7124_IO_CTRL1_REG_IOUT_CH1 (15));
+    regs[Reg_IOCon1].value |= AD7124_IO_CTRL1_REG_IOUT1 (current) | AD7124_IO_CTRL1_REG_IOUT_CH1 (ch);
+  }
+  Serial.println(regs[Reg_IOCon1].value, HEX);
+  return writeRegister (Reg_IOCon1);
+}
 
 // Sets the ADC Control register
 int Ad7124::setAdcControl(AD7124_OperatingModes mode,

--- a/src/NHB_AD7124.cpp
+++ b/src/NHB_AD7124.cpp
@@ -390,7 +390,6 @@ int Ad7124::setExCurrent(AD7124_ExCurrentOutputChannel ch, AD7124_ExCurrentSourc
     regs[Reg_IOCon1].value &= ~ (AD7124_IO_CTRL1_REG_IOUT1 (7) | AD7124_IO_CTRL1_REG_IOUT_CH1 (15));
     regs[Reg_IOCon1].value |= AD7124_IO_CTRL1_REG_IOUT1 (current) | AD7124_IO_CTRL1_REG_IOUT_CH1 (ch);
   }
-  Serial.println(regs[Reg_IOCon1].value, HEX);
   return writeRegister (Reg_IOCon1);
 }
 

--- a/src/NHB_AD7124.h
+++ b/src/NHB_AD7124.h
@@ -156,9 +156,8 @@ enum AD7124_BurnoutCurrents
     AD7124_Burnout_4uA      // burnout current source on, 4 μA.
 };
 
-// Excitation currents - Not used yet.
-// TODO: Look up actual value in datasheet (IO_CONTROL_1 Register)
-enum AD7124_ExCurrents
+// Excitation currents (page 84 of datasheet)
+enum AD7124_ExCurrent
 {
     AD7124_ExCurrent_Off = 0x00,
     AD7124_ExCurrent_50uA,
@@ -166,7 +165,28 @@ enum AD7124_ExCurrents
     AD7124_ExCurrent_250uA,
     AD7124_ExCurrent_500uA,
     AD7124_ExCurrent_750uA,
-    AD7124_ExCurrent_1mA
+    AD7124_ExCurrent_1000uA,
+    AD7124_ExCurrent_0_1uA
+};
+
+//excitation source channels
+enum AD7124_ExCurrentSource
+{
+    AD7124_ExCurrentSource_0 = 0x00,
+    AD7124_ExCurrentSource_1 = 0x01
+};
+
+//excitation output channels (page 84 of datasheet)
+enum AD7124_ExCurrentOutputChannel
+{
+    AD7124_ExCurrentOutputChannel_AIN0 = 0x0,
+    AD7124_ExCurrentOutputChannel_AIN1 = 0x1,
+    AD7124_ExCurrentOutputChannel_AIN2 = 0x4,
+    AD7124_ExCurrentOutputChannel_AIN3 = 0x5,
+    AD7124_ExCurrentOutputChannel_AIN4 = 0xA,
+    AD7124_ExCurrentOutputChannel_AIN5 = 0xB,
+    AD7124_ExCurrentOutputChannel_AIN6 = 0xE,
+    AD7124_ExCurrentOutputChannel_AIN7 = 0xF,
 };
 
 // Device register info
@@ -330,9 +350,6 @@ public:
 
     //Resets the Ad7124 by sending 64 consecutive 1s
     int reset();
-    
-
-
 
     //Read a single channel in single conversion mode and
     //return the value in raw ADC counts
@@ -375,9 +392,6 @@ public:
 
     //Converts a raw reading from the on chip temp sensor to degrees C
     double scaleIcTemp(double value);  
-
-
-
    
     //Enable or disable the onboard PWR_SW FET
     int setPWRSW(bool enabled);
@@ -386,7 +400,7 @@ public:
     int setVBias(AD7124_VBiasPins vBiasPin, bool enabled);
 
     //Set excitation current
-    //int setExCurrent(uint8_t ch, AD7124_ExCurrents); //NOT IMPLEMENTED YET
+    int setExCurrent(AD7124_ExCurrentOutputChannel ch, AD7124_ExCurrentSource source, AD7124_ExCurrent current);
 
     void setTimeout(uint32_t ms) { timeout = ms; }
 

--- a/src/NHB_AD7124.h
+++ b/src/NHB_AD7124.h
@@ -31,6 +31,7 @@
 #include <SPI.h>
 #include "AD_Defs.h"
 #include "Thermocouple.h"
+#include "RTD.h"
 
 #define AD7124_DEFAULT_TIMEOUT_MS 200 // milliseconds
 #define AD7124_MAX_CHANNELS 16 // not sure if this will be used yet
@@ -476,6 +477,7 @@ private:
 
     SPISettings spiSettings;
     Thermocouple thermocouple;
+    RTD rtd;
     bool crcEnabled = false;
     bool isReady = true; //Not really used now, may go away [8-26-21]
     uint8_t cs;

--- a/src/RTD.cpp
+++ b/src/RTD.cpp
@@ -1,0 +1,62 @@
+/*
+  This file is part of the NHB_AD7124 library.
+
+  Class for dealing with thermocouple calculations.
+
+  MIT License
+
+  Copyright (C) 2021  Jaimy Juliano
+  Copyright (C) 2025  Aaron Neal
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include "RTD.h"
+
+
+float RTD::adcRawToResistance(float adc, float gain, float rRef){
+    return ((adc-zero) * rRef) / (fullScale * gain - adc);
+}
+
+
+float RTD::resistanceToTemperature(float resistance, RtdTypes type = AUTO_DETECT){
+
+    float resPerDegree = 0;
+    float resistanceAtZero = 0;
+    switch (type)
+    {
+    case PT100:
+        resPerDegree = 0.385;
+        resistanceAtZero = 100;
+        break;
+    case PT1000:
+        resPerDegree = 3.85;
+        resistanceAtZero = 1000;
+        break;
+    case AUTO_DETECT:
+    default:
+        //if resistance is > 400 ohms it's a PT1000 (PT100 @ 390.26 = 850°C)
+        resPerDegree = resistance > 400 ? 0.385 : 3.85; 
+        resistanceAtZero = resistance > 400 ? 1000 : 100;
+        break;
+    }
+
+    return (resistance - resistanceAtZero) / resPerDegree;
+}
+

--- a/src/RTD.cpp
+++ b/src/RTD.cpp
@@ -31,11 +31,11 @@
 
 
 float RTD::adcRawToResistance(float adc, float gain, float rRef){
-    return ((adc-zero) * rRef) / (fullScale * gain - adc);
+    return ((adc-zero) * rRef) / (zero * gain);
 }
 
 
-float RTD::resistanceToTemperature(float resistance, RtdTypes type = AUTO_DETECT){
+float RTD::resistanceToTemperature(float resistance, RtdTypes type){
 
     float resPerDegree = 0;
     float resistanceAtZero = 0;
@@ -52,7 +52,7 @@ float RTD::resistanceToTemperature(float resistance, RtdTypes type = AUTO_DETECT
     case AUTO_DETECT:
     default:
         //if resistance is > 400 ohms it's a PT1000 (PT100 @ 390.26 = 850°C)
-        resPerDegree = resistance > 400 ? 0.385 : 3.85; 
+        resPerDegree = resistance > 400 ? 3.85 : 0.385; 
         resistanceAtZero = resistance > 400 ? 1000 : 100;
         break;
     }

--- a/src/RTD.h
+++ b/src/RTD.h
@@ -1,0 +1,55 @@
+#ifndef NHB_AD7124_RTD
+#define NHB_AD7124_RTD
+
+/*
+  This file is part of the NHB_AD7124 library.
+
+  Class for dealing with RTD (PT100/PT1000) calculations.
+
+  MIT License
+
+  Copyright (C) 2021  Jaimy Juliano
+  Copyright (C) 2025  Aaron Neal
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+
+#include <math.h>
+
+enum RtdTypes{
+    AUTO_DETECT = 0,
+    PT100 = 100, 
+    PT1000 = 1000,    
+};
+
+class RTD{
+    public:
+
+        float adcRawToResistance(float adc, float gain, float rRef);
+
+        float resistanceToTemperature(float resistance, RtdTypes type = AUTO_DETECT);
+
+    private:
+        const long zero = 1L << 23;
+        const long fullScale = 1L << 24;
+};
+
+
+ #endif //NHB_AD7124_RTD


### PR DESCRIPTION
Thanks for the library. I needed to measure RTD probes with the AD7124 and therefore required the current excitation implemented.

I have also added an example for 2 * 3-wire setup, however, there are a number of ways to read these probes (2/3/4 wire) with different current excitations required, so it is down to the user to do their own research for their exact HW configuration.

The RTD class is exposed publicly within the main class rather than wrapping it's functionality with more functions within the main class, I hope this is acceptable.

I have confirmed the excitation source outputs on each pin at 2 different currents.